### PR TITLE
Add fields to specify if dataset or model are required

### DIFF
--- a/instruments/iama.yaml
+++ b/instruments/iama.yaml
@@ -13,6 +13,8 @@ instrument:
       role: ""
   date: ""
   url: "https://www.rijksoverheid.nl/documenten/rapporten/2021/02/25/impact-assessment-mensenrechten-en-algoritmes"
+  model_required: true
+  dataset_required: true
 
 template: &systemcard_template                  # anchor for all fields belonging to answer
   question: "$QUESTION"

--- a/schema.json
+++ b/schema.json
@@ -59,6 +59,12 @@
         },
         "url": {
           "type": "string"
+        },
+        "model_required": {
+          "type": "boolean"
+        },
+        "dataset_required": {
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
# Description

Adds two fields
- model_required: bool
- dataset_required: bool
to specify whether an instrument needs to have a model or dataset. 

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
